### PR TITLE
Add COBRA transport plugin for boost_date_time_typekit types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ endif()
 
 orocos_generate_package()
 
+## Testing
+if(DEFINED CATKIN_ENABLE_TESTING)
+  set(BUILD_TESTING ${CATKIN_ENABLE_TESTING})
+endif()
 include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,4 +37,13 @@ install(
   RENAME Types.hpp
 )
 
+if(ENABLE_CORBA AND OROCOS-RTT_CORBA_FOUND)
+  add_subdirectory(src/corba)
+endif()
+
 orocos_generate_package()
+
+include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/include/orocos/boost_date_time_typekit/transports/corba/BoostDateTimeCorbaConversion.hpp
+++ b/include/orocos/boost_date_time_typekit/transports/corba/BoostDateTimeCorbaConversion.hpp
@@ -1,0 +1,195 @@
+/******************************************************************************
+*                                                                             *
+*       You may redistribute this software and/or modify it under either the  *
+*       terms of the GNU Lesser General Public License version 2.1 (LGPLv2.1  *
+*       <http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html>) or (at your *
+*       discretion) of the Modified BSD License:                              *
+*       Redistribution and use in source and binary forms, with or without    *
+*       modification, are permitted provided that the following conditions    *
+*       are met:                                                              *
+*       1. Redistributions of source code must retain the above copyright     *
+*       notice, this list of conditions and the following disclaimer.         *
+*       2. Redistributions in binary form must reproduce the above copyright  *
+*       notice, this list of conditions and the following disclaimer in the   *
+*       documentation and/or other materials provided with the distribution.  *
+*       3. The name of the author may not be used to endorse or promote       *
+*       products derived from this software without specific prior written    *
+*       permission.                                                           *
+*       THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR  *
+*       IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED        *
+*       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE    *
+*       ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,*
+*       INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    *
+*       (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS       *
+*       OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) *
+*       HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,   *
+*       STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING *
+*       IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE    *
+*       POSSIBILITY OF SUCH DAMAGE.                                           *
+*                                                                             *
+*******************************************************************************/
+
+#ifndef BOOST_DATE_TIME_TYPEKIT_TRANSPORT_CORBA_BOOST_DATE_TIME_CORBA_CONVERSION_HPP
+#define BOOST_DATE_TIME_TYPEKIT_TRANSPORT_CORBA_BOOST_DATE_TIME_CORBA_CONVERSION_HPP
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <rtt/transports/corba/CorbaConversion.hpp>
+
+namespace RTT {
+    namespace corba {
+
+        template<>
+        struct AnyConversion< boost::posix_time::ptime >
+        {
+            typedef CORBA::LongLong CorbaType;
+            typedef boost::posix_time::ptime StdType;
+
+            static const CorbaType not_a_date_time() {
+                return boost::date_time::int_adapter<CorbaType>::not_a_number().as_number();
+            }
+
+            static const CorbaType pos_infin() {
+                return boost::date_time::int_adapter<CorbaType>::pos_infinity().as_number();
+            }
+
+            static const CorbaType neg_infin() {
+                return boost::date_time::int_adapter<CorbaType>::neg_infinity().as_number();
+            }
+
+            static CorbaType toAny(const StdType& t) {
+                if (t.is_not_a_date_time()) {
+                    return not_a_date_time();
+                } else if (t.is_pos_infinity()) {
+                    return pos_infin();
+                } else if (t.is_neg_infinity()) {
+                    return neg_infin();
+                } else {
+                    static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
+                    boost::posix_time::time_duration d = t - epoch;
+                    return static_cast<CorbaType>(d.total_nanoseconds());
+                }
+            }
+
+            static bool updateAny( StdType const& t, CORBA::Any& any ) {
+                any <<= toAny( t );
+                return true;
+            }
+
+            static bool update(const CORBA::Any& any, StdType& _value) {
+                CorbaType result;
+                if ( any >>= result ) {
+                    return toStdType(_value, result);
+                }
+                return false;
+            }
+
+            static CORBA::Any_ptr createAny( const StdType& t ) {
+                CORBA::Any_ptr ret = new CORBA::Any();
+                *ret <<= toAny( t );
+                return ret;
+            }
+
+            static bool toCorbaType(CorbaType& cb, const StdType& tp) {
+                cb = toAny(tp);
+                return true;
+            }
+
+            static bool toStdType(StdType& tp, const CorbaType& cb) {
+                if (cb == not_a_date_time()) {
+                    tp = boost::posix_time::not_a_date_time;
+                    return true;
+                } else if (cb == pos_infin()) {
+                    tp = boost::posix_time::pos_infin;
+                    return true;
+                } else if (cb == neg_infin()) {
+                    tp = boost::posix_time::neg_infin;
+                    return true;
+                } else {
+#if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
+                    tp = boost::posix_time::from_time_t(0)
+                        + boost::posix_time::nanoseconds(cb);
+#else
+                    tp = boost::posix_time::from_time_t(0)
+                        + boost::posix_time::microseconds(cb / 1000ll);
+#endif
+                }
+            }
+        };
+
+        template<>
+        struct AnyConversion< boost::posix_time::time_duration >
+        {
+            typedef CORBA::LongLong CorbaType;
+            typedef boost::posix_time::time_duration StdType;
+
+            static const CorbaType not_a_date_time() {
+                return boost::date_time::int_adapter<CorbaType>::not_a_number().as_number();
+            }
+
+            static const CorbaType pos_infin() {
+                return boost::date_time::int_adapter<CorbaType>::pos_infinity().as_number();
+            }
+
+            static const CorbaType neg_infin() {
+                return boost::date_time::int_adapter<CorbaType>::neg_infinity().as_number();
+            }
+
+            static CorbaType toAny(const StdType& d) {
+                if (d.is_not_a_date_time()) {
+                  return not_a_date_time();
+                } else if (d.is_pos_infinity()) {
+                  return pos_infin();
+                } else if (d.is_neg_infinity()) {
+                  return neg_infin();
+                } else {
+                  return static_cast<CorbaType>(d.total_nanoseconds());
+                }
+            }
+
+            static bool updateAny( StdType const& t, CORBA::Any& any ) {
+                any <<= toAny( t );
+                return true;
+            }
+
+            static bool update(const CORBA::Any& any, StdType& _value) {
+                CorbaType result;
+                if ( any >>= result ) {
+                    return toStdType(_value, result);
+                }
+                return false;
+            }
+
+            static CORBA::Any_ptr createAny( const StdType& t ) {
+                CORBA::Any_ptr ret = new CORBA::Any();
+                *ret <<= toAny( t );
+                return ret;
+            }
+
+            static bool toCorbaType(CorbaType& cb, const StdType& tp) {
+                cb = toAny(tp);
+                return true;
+            }
+
+            static bool toStdType(StdType& tp, const CorbaType& cb) {
+                if (cb == not_a_date_time()) {
+                  tp = boost::posix_time::not_a_date_time;
+                } else if (cb == pos_infin()) {
+                  tp = boost::posix_time::pos_infin;
+                } else if (cb == neg_infin()) {
+                  tp = boost::posix_time::neg_infin;
+                } else {
+#if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
+                  tp = boost::posix_time::nanoseconds(cb);
+#else
+                  tp = boost::posix_time::microseconds(cb / 1000ll);
+#endif
+                }
+                return true;
+            }
+        };
+
+    }  // namespace corba
+}  // namespace RTT
+
+#endif // BOOST_DATE_TIME_TYPEKIT_TRANSPORT_CORBA_BOOST_DATE_TIME_CORBA_CONVERSION_HPP

--- a/include/orocos/boost_date_time_typekit/typekit/Types.hpp
+++ b/include/orocos/boost_date_time_typekit/typekit/Types.hpp
@@ -1,3 +1,34 @@
+/******************************************************************************
+*                                                                             *
+*       You may redistribute this software and/or modify it under either the  *
+*       terms of the GNU Lesser General Public License version 2.1 (LGPLv2.1  *
+*       <http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html>) or (at your *
+*       discretion) of the Modified BSD License:                              *
+*       Redistribution and use in source and binary forms, with or without    *
+*       modification, are permitted provided that the following conditions    *
+*       are met:                                                              *
+*       1. Redistributions of source code must retain the above copyright     *
+*       notice, this list of conditions and the following disclaimer.         *
+*       2. Redistributions in binary form must reproduce the above copyright  *
+*       notice, this list of conditions and the following disclaimer in the   *
+*       documentation and/or other materials provided with the distribution.  *
+*       3. The name of the author may not be used to endorse or promote       *
+*       products derived from this software without specific prior written    *
+*       permission.                                                           *
+*       THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR  *
+*       IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED        *
+*       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE    *
+*       ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,*
+*       INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    *
+*       (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS       *
+*       OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) *
+*       HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,   *
+*       STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING *
+*       IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE    *
+*       POSSIBILITY OF SUCH DAMAGE.                                           *
+*                                                                             *
+*******************************************************************************/
+
 #ifndef BOOST_DATE_TIME_TYPES_HPP
 #define BOOST_DATE_TIME_TYPES_HPP
 

--- a/src/corba/CMakeLists.txt
+++ b/src/corba/CMakeLists.txt
@@ -1,0 +1,7 @@
+orocos_typekit(boost_date_time_transport_corba boostDateTimeCorbaTransport.cpp)
+target_link_libraries(boost_date_time_transport_corba ${OROCOS-RTT_CORBA_LIBRARIES})
+
+install(
+  DIRECTORY ${PROJECT_SOURCE_DIR}/include/orocos/${PROJECT_NAME}/transports/corba/
+  DESTINATION include/orocos/${PROJECT_NAME}/transports/corba/
+)

--- a/src/corba/boostDateTimeCorbaTransport.cpp
+++ b/src/corba/boostDateTimeCorbaTransport.cpp
@@ -29,46 +29,46 @@
 *                                                                             *
 *******************************************************************************/
 
-#include "boostDateTimeTypekit.hpp"
-#include "boostDateTimeTypekitSpecialValues.hpp"
-#include "boostDateTimeTypekitPtime.hpp"
-#include "boostDateTimeTypekitTimeDuration.hpp"
+#include <rtt/transports/corba/CorbaTemplateProtocol.hpp>
+#include <rtt/types/TypekitPlugin.hpp>
+
+#include <boost_date_time_typekit/transports/corba/BoostDateTimeCorbaConversion.hpp>
+
+using namespace RTT;
+using namespace RTT::types;
+using namespace RTT::corba;
+
+#include <rtt/types/TransportPlugin.hpp>
 
 namespace boost_date_time_typekit {
-std::string BoostDateTimeTypekitPlugin::getName() {
-    return "boost-date_time";
+
+    namespace corba {
+
+        struct BoostDateTimeCorbaTransportPlugin : public RTT::types::TransportPlugin
+        {
+            bool registerTransport(std::string name, RTT::types::TypeInfo* ti)
+            {
+                if ( name == "boost.posix_time.ptime" )
+                    return ti->addProtocol(ORO_CORBA_PROTOCOL_ID, new CorbaTemplateProtocol< boost::posix_time::ptime >() );
+                if ( name == "boost.posix_time.time_duration" )
+                    return ti->addProtocol(ORO_CORBA_PROTOCOL_ID, new CorbaTemplateProtocol< boost::posix_time::time_duration >() );
+                return false;
+            }
+
+            std::string getTransportName() const {
+                return "CORBA";
+            }
+
+            std::string getName() const {
+                return "boost-date_time-transport-corba";
+            }
+
+            std::string getTypekitName() const {
+                return "boost-date_time";
+            }
+        };
+
+    }
 }
 
-bool BoostDateTimeTypekitPlugin::loadTypes() {
-    loadSpecialValuesTypes();
-    loadPtimeTypes();
-    loadTimeDurationTypes();
-    return true;
-}
-
-bool BoostDateTimeTypekitPlugin::loadConstructors() {
-    loadPtimeConstructors();
-    loadTimeDurationConstructors();
-    return true;
-}
-
-bool BoostDateTimeTypekitPlugin::loadOperators() {
-    loadPtimeOperators();
-    loadTimeDurationOperators();
-    return true;
-}
-
-bool BoostDateTimeTypekitPlugin::loadGlobals() {
-    loadSpecialValuesGlobals();
-    loadPtimeGlobals();
-    loadTimeDurationGlobals();
-    return true;
-}
-
-/**
- * The single global instance of the boostDateTime Typekit.
- */
-BoostDateTimeTypekitPlugin boostDateTimeTypekit;
-
-}  // namespace boost_date_time_typekit
-ORO_TYPEKIT_PLUGIN(boost_date_time_typekit::BoostDateTimeTypekitPlugin)
+ORO_TYPEKIT_PLUGIN( boost_date_time_typekit::corba::BoostDateTimeCorbaTransportPlugin )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+
+if(ENABLE_CORBA AND OROCOS-RTT_CORBA_FOUND)
+  orocos_executable(test_corba_transport test_corba_transport.cpp)
+  target_link_libraries(test_corba_transport
+    ${OROCOS-RTT_CORBA_LIBRARIES}
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES}
+  )
+  add_test(NAME test_corba_transport COMMAND test_corba_transport)
+  set_tests_properties(test_corba_transport
+    PROPERTIES ENVIRONMENT RTT_COMPONENT_PATH=${ORO_TYPEKIT_OUTPUT_DIRECTORY}/../..
+  )
+endif()

--- a/test/test_corba_transport.cpp
+++ b/test/test_corba_transport.cpp
@@ -59,12 +59,13 @@ struct BoostDateTimeCorbaTestSetup {
 };
 
 template<typename Predicate>
-bool waitFor(double timeout, Predicate pred) {
+bool waitFor(double timeout_s, Predicate pred) {
     const auto ts = os::TimeService::Instance();
-    os::TimeService::ticks start = ts->getTicks();
+    const auto sleep_time_us = static_cast<useconds_t>((timeout_s * 1e6) / 10);
+    const auto start = ts->getTicks();
     while (!pred()) {
-        if (ts->secondsSince(start) >= timeout) return false;
-        usleep(static_cast<useconds_t>((timeout / 10) * 100));
+        if (ts->secondsSince(start) >= timeout_s) return false;
+        usleep(sleep_time_us);
     }
     return true;
 }

--- a/test/test_corba_transport.cpp
+++ b/test/test_corba_transport.cpp
@@ -69,9 +69,7 @@ bool waitFor(double timeout, Predicate pred) {
     return true;
 }
 
-BOOST_AUTO_TEST_SUITE(
-    BoostDateTimeCorbaTest,
-    *boost::unit_test::fixture<BoostDateTimeCorbaTestSetup>());
+BOOST_GLOBAL_FIXTURE(BoostDateTimeCorbaTestSetup);
 
 BOOST_AUTO_TEST_CASE(RemoteConnectionPtime)
 {
@@ -129,8 +127,6 @@ BOOST_AUTO_TEST_CASE(RemoteConnectionPtime)
         BOOST_CHECK_EQUAL(read_sample, write_sample);
     }
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 int ORO_main(int argc, char* argv[]) {
     TaskContextServer::InitOrb(argc,argv);

--- a/test/test_corba_transport.cpp
+++ b/test/test_corba_transport.cpp
@@ -1,0 +1,145 @@
+/******************************************************************************
+*                                                                             *
+*       You may redistribute this software and/or modify it under either the  *
+*       terms of the GNU Lesser General Public License version 2.1 (LGPLv2.1  *
+*       <http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html>) or (at your *
+*       discretion) of the Modified BSD License:                              *
+*       Redistribution and use in source and binary forms, with or without    *
+*       modification, are permitted provided that the following conditions    *
+*       are met:                                                              *
+*       1. Redistributions of source code must retain the above copyright     *
+*       notice, this list of conditions and the following disclaimer.         *
+*       2. Redistributions in binary form must reproduce the above copyright  *
+*       notice, this list of conditions and the following disclaimer in the   *
+*       documentation and/or other materials provided with the distribution.  *
+*       3. The name of the author may not be used to endorse or promote       *
+*       products derived from this software without specific prior written    *
+*       permission.                                                           *
+*       THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR  *
+*       IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED        *
+*       WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE    *
+*       ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,*
+*       INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    *
+*       (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS       *
+*       OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) *
+*       HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,   *
+*       STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING *
+*       IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE    *
+*       POSSIBILITY OF SUCH DAMAGE.                                           *
+*                                                                             *
+*******************************************************************************/
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <rtt/RTT.hpp>
+#include <rtt/os/TimeService.hpp>
+#include <rtt/plugin/PluginLoader.hpp>
+#include <rtt/transports/corba/CorbaConnPolicy.hpp>
+#include <rtt/transports/corba/CorbaLib.hpp>
+#include <rtt/transports/corba/Corba.hpp>
+#include <rtt/transports/corba/TaskContextServer.hpp>
+
+#include <rtt/os/main.h>
+
+#include <unistd.h>
+
+#define BOOST_TEST_MODULE test_corba_transport
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+#include <boost/test/auto_unit_test.hpp>
+
+using namespace RTT;
+using namespace corba;
+
+struct BoostDateTimeCorbaTestSetup {
+    BoostDateTimeCorbaTestSetup()
+    {
+        plugin::PluginLoader::Instance()->loadTypekit("boost_date_time_typekit", "");
+    }
+};
+
+template<typename Predicate>
+bool waitFor(double timeout, Predicate pred) {
+    const auto ts = os::TimeService::Instance();
+    os::TimeService::ticks start = ts->getTicks();
+    while (!pred()) {
+        if (ts->secondsSince(start) >= timeout) return false;
+        usleep(static_cast<useconds_t>((timeout / 10) * 100));
+    }
+    return true;
+}
+
+BOOST_AUTO_TEST_SUITE(
+    BoostDateTimeCorbaTest,
+    *boost::unit_test::fixture<BoostDateTimeCorbaTestSetup>());
+
+BOOST_AUTO_TEST_CASE(RemoteConnectionPtime)
+{
+    TaskContext tca("a");
+    TaskContext tcb("b");
+    OutputPort<boost::posix_time::ptime> ptime_out("ptime");
+    InputPort<boost::posix_time::ptime> ptime_in("ptime");
+    OutputPort<boost::posix_time::time_duration> time_duration_out("time_duration");
+    InputPort<boost::posix_time::time_duration> time_duration_in("time_duration");
+    tca.addPort(ptime_out);
+    tcb.addPort(ptime_in);
+    tca.addPort(time_duration_out);
+    tcb.addPort(time_duration_in);
+
+    TaskContextServer* tsa = TaskContextServer::Create(&tca, false); //no-naming
+    TaskContextServer* tsb = TaskContextServer::Create(&tcb, false); //no-naming
+    CDataFlowInterface_var pa = tsa->server()->ports();
+    CDataFlowInterface_var pb = tsb->server()->ports();
+
+    // Create a default CORBA policy specification
+    CConnPolicy policy = toCORBA(ConnPolicy::data());
+    policy.init = false;
+    policy.transport = ORO_CORBA_PROTOCOL_ID; // force creation of non-local connections
+
+    // Connect ports
+    BOOST_REQUIRE( pa->createConnection("ptime", pb, "ptime", policy) );
+    BOOST_REQUIRE( pa->createConnection("time_duration", pb, "time_duration", policy) );
+
+    const std::initializer_list<boost::posix_time::ptime> ptime_samples{
+      boost::posix_time::microsec_clock::local_time(),
+      boost::posix_time::not_a_date_time,
+      boost::posix_time::pos_infin,
+      boost::posix_time::neg_infin
+    };
+    for(boost::posix_time::ptime write_sample : ptime_samples) {
+        boost::posix_time::ptime read_sample = boost::posix_time::from_time_t(0);
+        BOOST_CHECK_EQUAL(ptime_out.write(write_sample), WriteSuccess);
+        BOOST_CHECK(waitFor(1.0, [&](){ return ptime_in.read(read_sample) == NewData; }));
+        BOOST_CHECK_EQUAL(read_sample, write_sample);
+    }
+
+    const std::initializer_list<boost::posix_time::time_duration> time_duration_samples{
+      boost::posix_time::seconds(42.42),
+      boost::posix_time::seconds(-42.42),
+      boost::posix_time::microseconds(-1),
+      boost::posix_time::microseconds(-2),
+      boost::posix_time::not_a_date_time,
+      boost::posix_time::pos_infin,
+      boost::posix_time::neg_infin
+    };
+    for(boost::posix_time::time_duration write_sample : time_duration_samples) {
+        boost::posix_time::time_duration read_sample = boost::posix_time::time_duration();
+        BOOST_CHECK_EQUAL(time_duration_out.write(write_sample), WriteSuccess);
+        BOOST_CHECK(waitFor(1.0, [&](){ return time_duration_in.read(read_sample) == NewData; }));
+        BOOST_CHECK_EQUAL(read_sample, write_sample);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+int ORO_main(int argc, char* argv[]) {
+    TaskContextServer::InitOrb(argc,argv);
+    TaskContextServer::ThreadOrb();
+
+    int ret = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
+
+    TaskContextServer::ShutdownOrb(true);
+    TaskContextServer::DestroyOrb();
+
+    return ret;
+}


### PR DESCRIPTION
This new transport plugin allows to connect ports with `boost::posix_time::ptime` and `boost::posix_time::time_duration` types via CORBA.

The wire format is `long long`. Times are represented as nanoseconds since the Unix epoch, durations as nanoseconds. Special values are preserved.